### PR TITLE
add the convert image folder to list file script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ a) [tensorflow][1]
 b) [Pillow][2]
 2. You must have downloaded the [UCF101][3] (Action Recognition Data Set)
 3. Each single avi file is decoded with 5FPS (it's depend your decision) in a single directory.
-    - you can use the convert.sh file inside the list to decode the ucf101 video files
-    - run `python list/convert.sh .../UCF101/ 5`
+    - you can use the `./list/convert_video_to_images.sh` script to decode the ucf101 video files
+    - run `./list/convert_video_to_images.sh .../UCF101 5`
 4. Generate {train,test}.list files in `list` directory. Each line corresponds to "image directory" and a class (zero-based). For example:
+    - you can use the `./list/convert_images_to_list.sh` script to generate the {train,test}.list for the dataset
+    - run `./list/convert_images_to_list.sh .../dataset_images dataset_train`, this will generate `dataset_train.list` file inside the root folder
+
 ```
 database/ucf101/train/ApplyEyeMakeup/v_ApplyEyeMakeup_g01_c01 0
 database/ucf101/train/ApplyEyeMakeup/v_ApplyEyeMakeup_g01_c02 0
@@ -31,6 +34,7 @@ database/ucf101/train/BalanceBeam/v_BalanceBeam_g01_c03 4
 database/ucf101/train/BalanceBeam/v_BalanceBeam_g01_c04 4
 ...
 ```
+
 5. If you want to test my pre-trained model, you need to download my model from here: https://www.dropbox.com/sh/8wcjrcadx4r31ux/AAAkz3dQ706pPO8ZavrztRCca?dl=0
 
 ## Run command:

--- a/list/convert_images_to_list.sh
+++ b/list/convert_images_to_list.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# convert the images folder to the list file
+#   Usage:
+#       ./convert_images_to_list.sh path/to/video/ filename
+#   Example Usage:
+#       ./convert_images_to_list.sh ~/document/videofile kth_train
+#   Example Output(kth_train.list):
+#       /Volumes/passport/datasets/action_kth/origin_images/boxing/person01_boxing_d1_uncomp 0
+#       /Volumes/passport/datasets/action_kth/origin_images/boxing/person01_boxing_d2_uncomp 0
+#       ...
+#       /Volumes/passport/datasets/action_kth/origin_images/handclapping/person01_handclapping_d1_uncomp 1
+#       /Volumes/passport/datasets/action_kth/origin_images/handclapping/person01_handclapping_d2_uncomp 1
+#       ...
+
+COUNT=-1
+for folder in $1/*
+do
+    COUNT=$[ $COUNT + 1 ]
+    for imagesFolder in "$folder"/*
+    do
+        echo "$imagesFolder" $COUNT >> $2.list
+    done
+done

--- a/list/convert_video_to_images.sh
+++ b/list/convert_video_to_images.sh
@@ -2,9 +2,9 @@
 
 # convert the avi video to images
 #   Usage (sudo for the remove priviledge):
-#       sudo ./convert.sh path/to/video/ fps
+#       sudo ./convert_video_to_images.sh path/to/video fps
 #   Example Usage:
-#       sudo ./convert.sh ~/document/videofile/ 5
+#       sudo ./convert_video_to_images.sh ~/document/videofile/ 5
 #   Example Output:
 #       ~/document/videofile/walk/video1.avi 
 #       #=>
@@ -15,7 +15,7 @@
 #       ~/document/videofile/walk/video1/00005.jpg
 #       ...
 
-for folder in $1*
+for folder in $1/*
 do
     for file in "$folder"/*.avi
     do


### PR DESCRIPTION
1. 修改了之前list文件中的convert.sh的名字，让名字更能显示功能是什么
2. 添加了convert_images_to_list.sh的脚本文件， 可以将convert_video_to_images.sh脚本生成的文件夹结构的名字写入到文件当中，可以生成{train,test}.list文件.
3. 修改了readme